### PR TITLE
Handle communication errors before parsing plan

### DIFF
--- a/app.py
+++ b/app.py
@@ -219,11 +219,16 @@ Please generate an analysis plan using only the allowed functions."""
             system=system_prompt,
             model=st.session_state.get('selected_model', 'llama3.1:8b')
         )
-        
+
         # DEBUG: Show the raw response
         st.write("🔍 **Debug - Raw LLM Response:**")
         st.code(response)
-        
+
+        # Check for communication errors before attempting JSON parsing
+        if response.startswith("Error:") or "Failed to communicate" in response:
+            st.error(response)
+            return {"error": response}
+
         # Try multiple JSON extraction methods
         json_str = None
         


### PR DESCRIPTION
## Summary
- Check for communication errors in `generate_analysis_plan` and return user-facing error before JSON parsing.

## Testing
- `pytest -q` *(fails: TestPlanExecution.test_critical_error_stops_execution, TestFunctionRegistry.test_function_execution_with_args, TestExecutionResult.test_adding_errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb5b32fe88324a8ef022f78ede42f